### PR TITLE
Add `HAVE_STDINT_H` `HAVE_CSTDINT` flags to target defines for `libde265` support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,8 @@
     'defines': [
       'HAVE_POSIX_MEMALIGN',
       'HAVE_LIBDE265',
+      'HAVE_STDINT_H',
+      'HAVE_CSTDINT',
     ],
     'include_dirs' : [
       'src/',


### PR DESCRIPTION
Build fails when installing within a node app through normal means (npm, yarn), also when running `node-gyp configure && node-gyp build`, but succeeds when the following flags are present.